### PR TITLE
Docs: add issue 312 workflow demo marker

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,7 @@ This folder contains the project documentation for `cryptotrader`.
 - Repository-wide agent guidance is in `.github/copilot-instructions.md`
 - Path-specific instructions in `.github/instructions/`
 - The complete feature backlog is tracked in [GitHub Issues](https://github.com/m0nklabs/cryptotrader/issues)
+
+## Workflow Demo Marker
+
+- Issue #312 demonstrates the branch -> PR -> review -> merge workflow with a docs-only change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,4 @@ This folder contains the project documentation for `cryptotrader`.
 
 ## Workflow Demo Marker
 
-- Issue #312 demonstrates the branch -> PR -> review -> merge workflow with a docs-only change.
+- Issue #312 and PR #313 demonstrate the branch -> PR -> review -> merge workflow with a docs-only change.


### PR DESCRIPTION
## Summary
- Adds a tiny docs-only workflow demo marker to docs/README.md.

Closes #312

## Validation
- python3 inline docs marker assertion: passed
- git diff --check: passed
- pre-commit hooks during commit: passed

## Risk
- Docs-only change; no runtime behavior changes.

## Review handoff
- This PR intentionally expects one review round with findings, followed by a follow-up fix commit, to prove the end-to-end issue -> PR -> review -> merge workflow.