### PR TITLE
fix(api): load database URL from runtime env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-06-01
+### Dashboard DB Access Repair
+- Load the repo-local runtime environment file as a safe fallback when the API resolves `DATABASE_URL`, keeping explicit process environment values authoritative.
+- Add regression coverage for DB URL resolution so manually started API processes no longer break dashboard candle and market-watch endpoints.
+
 ## 2026-05-31
 ### Walk-Forward Validation Fix
 - Fix a post-merge regression in `core/strategy_eval/walk_forward.py` where warmup equity used `Decimal + float`, causing `TypeError` and breaking strict OOS walk-forward tests.

--- a/api/main.py
+++ b/api/main.py
@@ -97,10 +97,6 @@ def _get_database_url() -> str:
         return database_url
 
     runtime_env = _load_runtime_env()
-    database_url = os.environ.get("DATABASE_URL")
-    if database_url and database_url.strip():
-        return database_url
-
     runtime_database_url = runtime_env.get("DATABASE_URL")
     if runtime_database_url and runtime_database_url.strip():
         return runtime_database_url

--- a/api/main.py
+++ b/api/main.py
@@ -29,7 +29,11 @@ from decimal import Decimal
 from pathlib import Path as FilePath
 from typing import Any, Literal, Optional
 
-from dotenv import dotenv_values, load_dotenv
+try:
+    from dotenv import dotenv_values, load_dotenv
+except ImportError:  # pragma: no cover
+    dotenv_values = None  # type: ignore
+    load_dotenv = None  # type: ignore
 from fastapi import FastAPI, HTTPException, Query, Path
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
@@ -82,6 +86,8 @@ def _runtime_env_path() -> FilePath:
 
 def _load_runtime_env() -> dict[str, str]:
     """Load repo-local runtime environment defaults and return parsed values."""
+    if load_dotenv is None or dotenv_values is None:  # pragma: no cover
+        return {}
     dotenv_path = _runtime_env_path()
     if dotenv_path.is_file():
         load_dotenv(dotenv_path=str(dotenv_path), override=False)

--- a/api/main.py
+++ b/api/main.py
@@ -29,7 +29,7 @@ from decimal import Decimal
 from pathlib import Path as FilePath
 from typing import Any, Literal, Optional
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 from fastapi import FastAPI, HTTPException, Query, Path
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
@@ -72,30 +72,43 @@ from core.ratelimit import RateLimitMiddleware
 logger = logging.getLogger(__name__)
 
 _REPO_ROOT = FilePath(__file__).resolve().parents[1]
-_runtime_env_loaded = False
 
 
-def _load_runtime_env() -> None:
-    """Load repo-local runtime environment defaults once when needed."""
-    global _runtime_env_loaded
-    if _runtime_env_loaded:
-        return
+def _runtime_env_path() -> FilePath:
+    """Resolve the repo-local runtime environment file path."""
     env_path = os.environ.get("CRYPTOTRADER_ENV_FILE")
-    dotenv_path = FilePath(env_path).expanduser() if env_path else _REPO_ROOT / ".env"
+    return FilePath(env_path).expanduser() if env_path else _REPO_ROOT / ".env"
+
+
+def _load_runtime_env() -> dict[str, str]:
+    """Load repo-local runtime environment defaults and return parsed values."""
+    dotenv_path = _runtime_env_path()
     if dotenv_path.is_file():
         load_dotenv(dotenv_path=dotenv_path, override=False)
-    _runtime_env_loaded = True
+        return {key: value for key, value in dotenv_values(dotenv_path).items() if isinstance(value, str)}
+    return {}
 
 
 def _get_database_url() -> str:
     """Resolve DATABASE_URL from environment or the repo-local .env file."""
     database_url = os.environ.get("DATABASE_URL")
-    if not database_url:
-        _load_runtime_env()
-        database_url = os.environ.get("DATABASE_URL")
-    if not database_url:
-        raise RuntimeError("DATABASE_URL environment variable is required")
-    return database_url
+    if database_url and database_url.strip():
+        return database_url
+
+    runtime_env = _load_runtime_env()
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url and database_url.strip():
+        return database_url
+
+    runtime_database_url = runtime_env.get("DATABASE_URL")
+    if runtime_database_url and runtime_database_url.strip():
+        return runtime_database_url
+
+    runtime_env_path = _runtime_env_path()
+    raise RuntimeError(
+        "DATABASE_URL environment variable is required "
+        f"(checked environment and runtime env file: {runtime_env_path})"
+    )
 
 
 @asynccontextmanager

--- a/api/main.py
+++ b/api/main.py
@@ -26,8 +26,10 @@ from contextlib import asynccontextmanager
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path as FilePath
 from typing import Any, Literal, Optional
 
+from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Query, Path
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
@@ -68,6 +70,32 @@ from api.routes import (
 from core.ratelimit import RateLimitMiddleware
 
 logger = logging.getLogger(__name__)
+
+_REPO_ROOT = FilePath(__file__).resolve().parents[1]
+_runtime_env_loaded = False
+
+
+def _load_runtime_env() -> None:
+    """Load repo-local runtime environment defaults once when needed."""
+    global _runtime_env_loaded
+    if _runtime_env_loaded:
+        return
+    env_path = os.environ.get("CRYPTOTRADER_ENV_FILE")
+    dotenv_path = FilePath(env_path).expanduser() if env_path else _REPO_ROOT / ".env"
+    if dotenv_path.is_file():
+        load_dotenv(dotenv_path=dotenv_path, override=False)
+    _runtime_env_loaded = True
+
+
+def _get_database_url() -> str:
+    """Resolve DATABASE_URL from environment or the repo-local .env file."""
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        _load_runtime_env()
+        database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+    return database_url
 
 
 @asynccontextmanager
@@ -255,10 +283,7 @@ def _get_stores() -> PostgresStores:
     """Get or initialize the database stores."""
     global _stores
     if _stores is None:
-        database_url = os.environ.get("DATABASE_URL")
-        if not database_url:
-            raise RuntimeError("DATABASE_URL environment variable is required")
-        _stores = PostgresStores(config=PostgresConfig(database_url=database_url))
+        _stores = PostgresStores(config=PostgresConfig(database_url=_get_database_url()))
     return _stores
 
 

--- a/api/main.py
+++ b/api/main.py
@@ -84,7 +84,7 @@ def _load_runtime_env() -> dict[str, str]:
     """Load repo-local runtime environment defaults and return parsed values."""
     dotenv_path = _runtime_env_path()
     if dotenv_path.is_file():
-        load_dotenv(dotenv_path=dotenv_path, override=False)
+        load_dotenv(dotenv_path=str(dotenv_path), override=False)
         parsed_values = dotenv_values(dotenv_path)
         return {key: value for key, value in parsed_values.items() if isinstance(value, str)}
     return {}

--- a/api/main.py
+++ b/api/main.py
@@ -85,7 +85,8 @@ def _load_runtime_env() -> dict[str, str]:
     dotenv_path = _runtime_env_path()
     if dotenv_path.is_file():
         load_dotenv(dotenv_path=dotenv_path, override=False)
-        return {key: value for key, value in dotenv_values(dotenv_path).items() if isinstance(value, str)}
+        parsed_values = dotenv_values(dotenv_path)
+        return {key: value for key, value in parsed_values.items() if isinstance(value, str)}
     return {}
 
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -41,6 +41,7 @@ def test_database_url_env_var_wins_over_runtime_env_file(tmp_path, monkeypatch) 
     assert main._get_database_url() == "postgresql://explicit:test@127.0.0.1:5432/cryptotrader"
 
 
+# Regression: an empty DATABASE_URL must still allow runtime env fallback loading.
 def test_database_url_empty_falls_back_to_runtime_env_file(tmp_path, monkeypatch) -> None:
     """Verify DATABASE_URL present but empty falls back to runtime env file."""
     from api import main

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -54,6 +54,18 @@ def test_database_url_empty_falls_back_to_runtime_env_file(tmp_path, monkeypatch
     assert main._get_database_url() == "postgresql://fallback:test@127.0.0.1:5432/cryptotrader"
 
 
+def test_database_url_whitespace_only_falls_back_to_runtime_env_file(tmp_path, monkeypatch) -> None:
+    """Verify DATABASE_URL with only whitespace falls back to runtime env file."""
+    from api import main
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URL=postgresql://whitespace:test@127.0.0.1:5432/cryptotrader\n")
+    monkeypatch.setenv("DATABASE_URL", "   ")  # Whitespace only
+    monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
+
+    assert main._get_database_url() == "postgresql://whitespace:test@127.0.0.1:5432/cryptotrader"
+
+
 def test_get_candles_latest_uses_default_exchange(api_client) -> None:
     """Verify /candles/latest endpoint uses default exchange when not provided.
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -17,6 +17,32 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 
+def test_database_url_loads_from_runtime_env_file(tmp_path, monkeypatch) -> None:
+    """Verify DATABASE_URL falls back to the configured runtime env file."""
+    from api import main
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URL=postgresql://local:test@127.0.0.1:5432/cryptotrader\n")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
+    monkeypatch.setattr(main, "_runtime_env_loaded", False)
+
+    assert main._get_database_url() == "postgresql://local:test@127.0.0.1:5432/cryptotrader"
+
+
+def test_database_url_env_var_wins_over_runtime_env_file(tmp_path, monkeypatch) -> None:
+    """Verify an explicit DATABASE_URL is never overwritten by .env loading."""
+    from api import main
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URL=postgresql://file:test@127.0.0.1:5432/cryptotrader\n")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://explicit:test@127.0.0.1:5432/cryptotrader")
+    monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
+    monkeypatch.setattr(main, "_runtime_env_loaded", False)
+
+    assert main._get_database_url() == "postgresql://explicit:test@127.0.0.1:5432/cryptotrader"
+
+
 def test_get_candles_latest_uses_default_exchange(api_client) -> None:
     """Verify /candles/latest endpoint uses default exchange when not provided.
 

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -25,7 +25,6 @@ def test_database_url_loads_from_runtime_env_file(tmp_path, monkeypatch) -> None
     env_file.write_text("DATABASE_URL=postgresql://local:test@127.0.0.1:5432/cryptotrader\n")
     monkeypatch.delenv("DATABASE_URL", raising=False)
     monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
-    monkeypatch.setattr(main, "_runtime_env_loaded", False)
 
     assert main._get_database_url() == "postgresql://local:test@127.0.0.1:5432/cryptotrader"
 
@@ -38,9 +37,20 @@ def test_database_url_env_var_wins_over_runtime_env_file(tmp_path, monkeypatch) 
     env_file.write_text("DATABASE_URL=postgresql://file:test@127.0.0.1:5432/cryptotrader\n")
     monkeypatch.setenv("DATABASE_URL", "postgresql://explicit:test@127.0.0.1:5432/cryptotrader")
     monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
-    monkeypatch.setattr(main, "_runtime_env_loaded", False)
 
     assert main._get_database_url() == "postgresql://explicit:test@127.0.0.1:5432/cryptotrader"
+
+
+def test_database_url_empty_falls_back_to_runtime_env_file(tmp_path, monkeypatch) -> None:
+    """Verify DATABASE_URL present but empty falls back to runtime env file."""
+    from api import main
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("DATABASE_URL=postgresql://fallback:test@127.0.0.1:5432/cryptotrader\n")
+    monkeypatch.setenv("DATABASE_URL", "")  # Empty string
+    monkeypatch.setenv("CRYPTOTRADER_ENV_FILE", str(env_file))
+
+    assert main._get_database_url() == "postgresql://fallback:test@127.0.0.1:5432/cryptotrader"
 
 
 def test_get_candles_latest_uses_default_exchange(api_client) -> None:

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -41,7 +41,7 @@ def test_database_url_env_var_wins_over_runtime_env_file(tmp_path, monkeypatch) 
     assert main._get_database_url() == "postgresql://explicit:test@127.0.0.1:5432/cryptotrader"
 
 
-# Regression: an empty DATABASE_URL must still allow runtime env fallback loading.
+# Regression: empty DATABASE_URL must still allow runtime env fallback loading.
 def test_database_url_empty_falls_back_to_runtime_env_file(tmp_path, monkeypatch) -> None:
     """Verify DATABASE_URL present but empty falls back to runtime env file."""
     from api import main


### PR DESCRIPTION
## Summary
- Load the repo-local runtime env file as a safe fallback when resolving DATABASE_URL in the FastAPI app.
- Keep explicit process environment values authoritative so systemd/container overrides still win.
- Add regression tests for DATABASE_URL fallback and precedence.

## Validation
- .venv/bin/python -m pytest tests/test_api_endpoints.py -q
- .venv/bin/python -m ruff check api/main.py tests/test_api_endpoints.py
- systemctl --user restart cryptotrader-api
- http://127.0.0.1:8000/health -> 200
- http://127.0.0.1:8000/candles/available?exchange=bitfinex -> 200
- http://127.0.0.1:5176/api/candles/available?exchange=bitfinex -> 200

## Operational note
The live 500s were caused by a stale manually-started uvicorn process owning port 8000 without DATABASE_URL. That orphan process was stopped and the managed cryptotrader-api user service now owns port 8000.