### PR TITLE
fix(github): require manual merge gatekeeper

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -171,7 +171,7 @@ pull_request_rules:
           - approved-reviews-by=m0nk1111
       # Copilot Reviewer must NOT have outstanding comments (state != COMMENTED)
       - or:
-          - -review-requested=copilot-pull-request-reviewer[bot]
+          - "-review-requested=copilot-pull-request-reviewer[bot]"
           - "#changes-requested-reviews-by=0"
       # Use Copilot CI check (push-triggered) instead of PR checks (which get blocked)
       - or:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -144,11 +144,11 @@ pull_request_rules:
         add:
           - copilot
 
-  # ========== Auto-merge ==========
-  # NOTE: Branch deletion after merge is handled by GitHub's repository setting
-  # 'Automatically delete head branches', as the 'delete_head_branch' action is deprecated.
+  # ========== Manual merge gatekeeper ==========
+  # Automatic merge is intentionally disabled while the PR flow is audited.
+  # Mergify may mark candidates, but Flip merges manually.
 
-  - name: auto-merge-dependabot
+  - name: mark-manual-merge-candidate-dependabot
     conditions:
       - author=dependabot[bot]
       - check-success=Backend (ruff + pytest)
@@ -156,10 +156,11 @@ pull_request_rules:
       - -conflict
       - -draft
     actions:
-      merge:
-        method: squash
+      label:
+        add:
+          - ready-for-manual-merge
 
-  - name: auto-merge-copilot
+  - name: mark-manual-merge-candidate-copilot
     conditions:
       - or:
           - author=github-actions[bot]
@@ -184,12 +185,13 @@ pull_request_rules:
       - -label=do-not-merge
       - -label=work-in-progress
     actions:
-      merge:
-        method: squash
+      label:
+        add:
+          - ready-for-manual-merge
 
-  - name: auto-merge-approved
+  - name: mark-manual-merge-candidate-approved
     conditions:
-      - label=automerge
+      - label=manual-approved-by-flip
       - "#approved-reviews-by>=1"
       - check-success=Backend (ruff + pytest)
       - check-success=Pre-commit checks
@@ -198,8 +200,9 @@ pull_request_rules:
       - -draft
       - -label=do-not-merge
     actions:
-      merge:
-        method: squash
+      label:
+        add:
+          - ready-for-manual-merge
 
   - name: request-review-on-ready
     conditions:

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -148,25 +148,25 @@ def count_dep_files(pr: dict) -> int:
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Explicit dependency manifest and frontend path checking
-        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+        # Only count actual dependency manifest files
+        if any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS):
             count += 1
-        elif any(filename.startswith(p) for p in FRONTEND_PATHS):
+        elif filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/")):
             count += 1
     return count
 
 
 def is_limited_scope(pr: dict) -> bool:
-    """Check if PR scope is limited to dependency manifests and frontend paths."""
+    """Check if PR scope is limited to dependency manifest files."""
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Explicit check: only dependency manifests and frontend paths allowed
-        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
-            continue
-        if any(filename.startswith(p) for p in FRONTEND_PATHS):
-            continue
-        return False  # Has non-dependency files
+        # Check if file is a dependency manifest file
+        is_dep_file = any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS)
+        is_frontend_dep = filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/"))
+        
+        if not (is_dep_file or is_frontend_dep):
+            return False  # Any non-dependency file makes this false
     return True  # All files are dependency-related
 
 
@@ -245,7 +245,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
             age_days=age_days,
             num_files=num_files,
         )
-    elif is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
+    elif is_dep and ci_pass and not has_conflicts(pr) and not is_draft(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
         # Tier 1: Auto-Merge
         return _classification_result(
             pr,
@@ -257,7 +257,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
             age_days=age_days,
             num_files=num_files,
         )
-    elif ci_pass and not has_conflicts(pr) and (age_days >= 7 or num_files >= 3):
+    elif ci_pass and not has_conflicts(pr) and not is_draft(pr) and (age_days >= 7 or num_files >= 3):
         # Tier 2: Auto-Approve
         return _classification_result(
             pr,

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -180,85 +180,107 @@ def get_pr_age_days(pr: dict) -> int:
     return (now - created_dt).days
 
 
+def _classification_result(
+    pr: dict,
+    *,
+    tier: int,
+    action: str,
+    reason: str,
+    ci_pass: bool,
+    check_map: dict[str, str],
+    age_days: int,
+    num_files: int,
+) -> dict:
+    return {
+        "pr": pr,
+        "tier": tier,
+        "action": action,
+        "reason": reason,
+        "ci_pass": ci_pass,
+        "check_map": check_map,
+        "age_days": age_days,
+        "num_files": num_files,
+    }
+
+
 def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
     """Classify a PR for auto-review.
 
     Returns a dict with classification details.
     """
     ci_pass, check_map = check_ci_status(check_runs)
-    age_days = get_pr_age_days(pr)
-    num_files = count_dep_files(pr)
+    age_days, num_files = get_pr_age_days(pr), count_dep_files(pr)
     is_dep = is_dependabot_pr(pr)
 
     if not ci_pass:
-        return {
-            "pr": pr,
-            "tier": 3,
-            "action": "comment",
-            "reason": "CI checks not all passing",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=3,
+            action="comment",
+            reason="CI checks not all passing",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
     elif has_conflicts(pr):
-        return {
-            "pr": pr,
-            "tier": 3,
-            "action": "comment",
-            "reason": "Merge conflicts detected",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=3,
+            action="comment",
+            reason="Merge conflicts detected",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
     elif is_draft(pr):
-        return {
-            "pr": pr,
-            "tier": 3,
-            "action": "comment",
-            "reason": "PR is draft",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=3,
+            action="comment",
+            reason="PR is draft",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
     elif is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
         # Tier 1: Auto-Merge
-        return {
-            "pr": pr,
-            "tier": 1,
-            "action": "merge",
-            "reason": f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=1,
+            action="merge",
+            reason=f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
     elif ci_pass and not has_conflicts(pr) and (age_days >= 7 or num_files >= 3):
         # Tier 2: Auto-Approve
-        return {
-            "pr": pr,
-            "tier": 2,
-            "action": "auto-approve",
-            "reason": f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=2,
+            action="auto-approve",
+            reason=f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
     else:
         # Tier 3: Manual
-        return {
-            "pr": pr,
-            "tier": 3,
-            "action": "comment",
-            "reason": "Does not meet auto-approval criteria",
-            "ci_pass": ci_pass,
-            "check_map": check_map,
-            "age_days": age_days,
-            "num_files": num_files,
-        }
+        return _classification_result(
+            pr,
+            tier=3,
+            action="comment",
+            reason="Does not meet auto-approval criteria",
+            ci_pass=ci_pass,
+            check_map=check_map,
+            age_days=age_days,
+            num_files=num_files,
+        )
 
 
 def apply_action(pr_class: dict, dry_run: bool = False) -> str:

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -151,8 +151,6 @@ def count_dep_files(pr: dict) -> int:
             count += 1
         elif any(filename.startswith(p) for p in FRONTEND_PATHS):
             count += 1
-        else:
-            count += 1  # Count all files for simplicity
     return count
 
 
@@ -169,7 +167,7 @@ def is_limited_scope(pr: dict) -> bool:
         # If file is in core/ or api/ but it's a dependency update, still limited
         if filename.startswith(("core/", "api/", "cex/", "db/")):
             continue
-        return True  # Has non-dependency files
+        return False  # Has non-dependency files
     return True  # All files are dependency-related
 
 
@@ -211,7 +209,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
         is_dep = is_dependabot_pr(pr)
 
         # Tier 1: Auto-Merge
-        if is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2:
+        if is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
             tier = 1
             action = "merge"
             reason = f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)"

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -48,8 +48,8 @@ DEP_PATHS = {
     "Makefile",
 }
 
-# Frontend paths
-FRONTEND_PATHS = {"frontend/", "frontend/package.json", "frontend/package-lock.json"}
+# Frontend dependency manifests
+FRONTEND_PATHS = {"frontend/package.json", "frontend/package-lock.json"}
 
 # Core dependency paths (major updates to these need manual review)
 CORE_DEPS = {"fastapi", "sqlalchemy", "pydantic", "numpy", "pandas", "uvicorn", "gunicorn"}
@@ -142,16 +142,17 @@ def has_conflicts(pr: dict) -> bool:
     return str(pr.get("mergeStateStatus") or "").upper() == "DIRTY"
 
 
+def _is_dependency_manifest_file(filename: str) -> bool:
+    return any(filename == path or filename.endswith("/" + path) for path in DEP_PATHS) or filename in FRONTEND_PATHS
+
+
 def count_dep_files(pr: dict) -> int:
     """Count the number of dependency manifest files changed."""
     files = pr.get("files", [])
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Only count actual dependency manifest files
-        if any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS):
-            count += 1
-        elif filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/")):
+        if _is_dependency_manifest_file(filename):
             count += 1
     return count
 
@@ -161,12 +162,8 @@ def is_limited_scope(pr: dict) -> bool:
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Check if file is a dependency manifest file
-        is_dep_file = any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS)
-        is_frontend_dep = filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/"))
-        
-        if not (is_dep_file or is_frontend_dep):
-            return False  # Any non-dependency file makes this false
+        if not _is_dependency_manifest_file(filename):
+            return False
     return True  # All files are dependency-related
 
 
@@ -245,7 +242,15 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
             age_days=age_days,
             num_files=num_files,
         )
-    elif is_dep and ci_pass and not has_conflicts(pr) and not is_draft(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
+    elif (
+        is_dep
+        and ci_pass
+        and not has_conflicts(pr)
+        and not is_draft(pr)
+        and age_days < 7
+        and num_files <= 2
+        and is_limited_scope(pr)
+    ):
         # Tier 1: Auto-Merge
         return _classification_result(
             pr,

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+Auto-review logic for dependency PRs in cryptotrader.
+
+Checks CI status and applies auto-approval or adds comments based on
+the rules defined in the dependency-pr-automation skill.
+
+Usage:
+    python auto_review_deps.py [--dry-run] [--pr <number>] [--verbose]
+"""
+
+import subprocess
+import json
+import sys
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Configuration
+WORK_DIR = Path("/home/flip/cryptotrader")
+KNOWN_AUTHORS = {"dependabot[bot]", "app/dependabot", "Copilot", "github-actions[bot]", "m0nk111", "m0nk1111"}
+
+# CI check names - maps from actual GitHub check run names to mergify.yml expectations
+CI_CHECK_MAPPING = {
+    "Analyze (python)": "Backend (ruff + pytest)",
+    "Analyze (javascript)": "Pre-commit checks",
+    "Gitleaks": "Gitleaks",
+    "CodeQL": "CodeQL",
+    "Summary": "Summary",
+}
+
+# Required CI checks for auto-approval
+REQUIRED_CHECKS = {"Backend (ruff + pytest)", "Pre-commit checks", "Gitleaks"}
+
+# Dependency paths that count as limited scope
+DEP_PATHS = {
+    "package.json",
+    "package-lock.json",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    ".pre-commit-config.yaml",
+    ".editorconfig",
+    "docker-compose.yml",
+    "docker-compose.dev.yml",
+    "Makefile",
+}
+
+# Frontend paths
+FRONTEND_PATHS = {"frontend/", "frontend/package.json", "frontend/package-lock.json"}
+
+# Core dependency paths (major updates to these need manual review)
+CORE_DEPS = {"fastapi", "sqlalchemy", "pydantic", "numpy", "pandas", "uvicorn", "gunicorn"}
+
+
+def run_cmd(cmd: str, cwd=None) -> tuple[int, str, str]:
+    """Run a shell command and return (exit_code, stdout, stderr)."""
+    result = subprocess.run(cmd, shell=True, cwd=cwd or str(WORK_DIR), capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def get_open_dependabot_prs() -> list[dict]:
+    """Get all open dependabot PRs with details."""
+    rc, out, err = run_cmd(
+        "gh pr list --state open --json number,title,author,createdAt,updatedAt,state,"
+        "mergeStateStatus,labels,commits,statusCheckRollup,files,isDraft,body"
+    )
+    if rc != 0:
+        print(f"Error getting PRs: {err}", file=sys.stderr)
+        return []
+
+    prs = json.loads(out)
+    return [p for p in prs if "dependabot" in p.get("author", {}).get("login", "")]
+
+
+def get_pr_check_runs(pr_number: int) -> list[dict]:
+    """Get check runs for a specific PR."""
+    # Get the head commit SHA
+    rc, out, _ = run_cmd(f"gh pr view {pr_number} --json headRefOid")
+    if rc != 0:
+        return []
+    head_sha = json.loads(out).get("headRefOid", "")
+    if not head_sha:
+        return []
+
+    # Get check runs for the head commit
+    rc, out, _ = run_cmd(f"gh api repos/m0nklabs/cryptotrader/commits/{head_sha}/check-runs")
+    if rc != 0:
+        return []
+
+    data = json.loads(out)
+    return data.get("check_runs", [])
+
+
+def check_ci_status(check_runs: list[dict]) -> tuple[bool, dict[str, str]]:
+    """Check if all required CI checks pass.
+
+    Returns (all_pass, check_status_dict).
+    """
+    # Build a map of check name -> status
+    check_map = {}
+    for cr in check_runs:
+        name = cr.get("name", "")
+        status = cr.get("status", "")
+
+        # Map actual check names to mergify expectations
+        mapped_name = CI_CHECK_MAPPING.get(name, name)
+        check_map[mapped_name] = status
+
+    # Check required checks
+    all_pass = True
+    for req in REQUIRED_CHECKS:
+        status = check_map.get(req)
+        if status not in ("completed", "success", "passed", "COMPLETED", "SUCCESS", "pass"):
+            all_pass = False
+
+    return all_pass, check_map
+
+
+def is_dependabot_pr(pr: dict) -> bool:
+    """Check if PR is from dependabot."""
+    author = pr.get("author", {}).get("login", "")
+    return "dependabot" in author.lower()
+
+
+def is_known_author(pr: dict) -> bool:
+    """Check if PR author is known."""
+    author = pr.get("author", {}).get("login", "")
+    return author in KNOWN_AUTHORS or "dependabot" in author.lower()
+
+
+def is_draft(pr: dict) -> bool:
+    """Check if PR is a draft."""
+    return pr.get("isDraft", False)
+
+
+def has_conflicts(pr: dict) -> bool:
+    """Check if PR has merge conflicts."""
+    return pr.get("mergeStateStatus") != "CLEAN"
+
+
+def count_dep_files(pr: dict) -> int:
+    """Count the number of dependency-related files changed."""
+    files = pr.get("files", [])
+    count = 0
+    for f in files:
+        filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+            count += 1
+        elif any(filename.startswith(p) for p in FRONTEND_PATHS):
+            count += 1
+        else:
+            count += 1  # Count all files for simplicity
+    return count
+
+
+def is_limited_scope(pr: dict) -> bool:
+    """Check if PR scope is limited to dependency paths."""
+    files = pr.get("files", [])
+    for f in files:
+        filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        # Check if file is in a dependency-related path
+        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+            continue
+        if any(filename.startswith(p) for p in FRONTEND_PATHS):
+            continue
+        # If file is in core/ or api/ but it's a dependency update, still limited
+        if filename.startswith(("core/", "api/", "cex/", "db/")):
+            continue
+        return True  # Has non-dependency files
+    return True  # All files are dependency-related
+
+
+def get_pr_age_days(pr: dict) -> int:
+    """Get the age of the PR in days."""
+    created = pr.get("createdAt", "")
+    if not created:
+        return 0
+    created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    now = datetime.now(timezone.utc)
+    return (now - created_dt).days
+
+
+def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
+    """Classify a PR for auto-review.
+
+    Returns a dict with classification details.
+    """
+    ci_pass, check_map = check_ci_status(check_runs)
+    tier = 3  # Default to manual
+    action = "none"
+    reason = ""
+
+    if not ci_pass:
+        tier = 3
+        action = "comment"
+        reason = "CI checks not all passing"
+    elif has_conflicts(pr):
+        tier = 3
+        action = "comment"
+        reason = "Merge conflicts detected"
+    elif is_draft(pr):
+        tier = 3
+        action = "label"
+        reason = "PR is draft"
+    else:
+        age_days = get_pr_age_days(pr)
+        num_files = count_dep_files(pr)
+        is_dep = is_dependabot_pr(pr)
+
+        # Tier 1: Auto-Merge
+        if is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2:
+            tier = 1
+            action = "merge"
+            reason = f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)"
+
+        # Tier 2: Auto-Approve
+        elif ci_pass and not has_conflicts(pr):
+            if age_days >= 7 or num_files >= 3:
+                tier = 2
+                action = "auto-approve"
+                reason = f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)"
+            else:
+                tier = 2
+                action = "auto-approve"
+                reason = f"CI pass, no conflicts, {age_days}d old"
+
+        # Tier 3: Manual
+        else:
+            tier = 3
+            action = "comment"
+            reason = "Does not meet auto-approval criteria"
+
+    return {
+        "pr": pr,
+        "tier": tier,
+        "action": action,
+        "reason": reason,
+        "ci_pass": ci_pass,
+        "check_map": check_map,
+        "age_days": get_pr_age_days(pr),
+        "num_files": count_dep_files(pr),
+    }
+
+
+def apply_action(pr_class: dict, dry_run: bool = False) -> str:
+    """Apply the auto-review action for a classified PR.
+
+    Returns a message describing what was done.
+    """
+    pr = pr_class["pr"]
+    pr_num = pr["number"]
+    action = pr_class["action"]
+    tier = pr_class["tier"]
+    reason = pr_class["reason"]
+
+    if dry_run:
+        return f"[DRY RUN] PR #{pr_num}: Tier {tier} -> {action} ({reason})"
+
+    if action == "merge":
+        # Manual gatekeeper mode: mark the PR for manual merge review.
+        labels = [label["name"] for label in pr.get("labels", [])]
+        if "ready-for-manual-merge" not in labels:
+            run_cmd(f"gh pr edit {pr_num} --add-label ready-for-manual-merge")
+        return f"PR #{pr_num}: Ready for manual merge review"
+
+    elif action == "auto-approve":
+        # Manual gatekeeper mode: mark the PR for manual merge review.
+        labels = [label["name"] for label in pr.get("labels", [])]
+        if "ready-for-manual-merge" not in labels:
+            run_cmd(f"gh pr edit {pr_num} --add-label ready-for-manual-merge")
+        return f"PR #{pr_num}: Ready for manual merge review"
+
+    elif action == "comment":
+        # Add a comment
+        comment = f"🤖 Auto-review: Tier {tier} - {reason}\n\n"
+        comment += f"CI pass: {pr_class['ci_pass']}\n"
+        comment += f"Age: {pr_class['age_days']} days\n"
+        comment += f"Files changed: {pr_class['num_files']}\n"
+
+        run_cmd(f'gh pr comment {pr_num} --body "{comment}"')
+        return f"PR #{pr_num}: Added comment (Tier {tier})"
+
+    return f"PR #{pr_num}: No action needed"
+
+
+def run_auto_review(dry_run: bool = False, pr_number: int = None, verbose: bool = False):
+    """Run the auto-review logic for dependency PRs."""
+    print("=" * 60)
+    print("Dependency PR Auto-Review")
+    print("=" * 60)
+
+    # Get PRs
+    if pr_number:
+        all_prs = get_open_dependabot_prs()
+        prs = [all_prs[0]] if all_prs else []
+        # Filter by number if specified
+        prs = [p for p in prs if p["number"] == pr_number]
+    else:
+        prs = get_open_dependabot_prs()
+
+    print(f"\nFound {len(prs)} open dependabot PRs\n")
+
+    results = []
+    for pr in prs:
+        # Get check runs
+        check_runs = get_pr_check_runs(pr["number"])
+
+        # Classify
+        pr_class = classify_pr(pr, check_runs)
+
+        if verbose:
+            print(f"PR #{pr['number']}: {pr['title']}")
+            print(f"  Author: {pr['author']['login']}")
+            print(f"  Age: {pr_class['age_days']} days, Files: {pr_class['num_files']}")
+            print(f"  CI pass: {pr_class['ci_pass']}")
+            print(f"  Checks: {pr_class['check_map']}")
+            print(f"  Merge status: {pr['mergeStateStatus']}")
+            print(f"  Tier: {pr_class['tier']}, Action: {pr_class['action']}")
+            print(f"  Reason: {pr_class['reason']}")
+            print()
+
+        # Apply action
+        result = apply_action(pr_class, dry_run)
+        results.append(result)
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("Summary:")
+    print("=" * 60)
+    for r in results:
+        print(f"  {r}")
+
+    # Print tier distribution
+    tiers = {}
+    for r in results:
+        for i, pr in enumerate(prs):
+            if f"PR #{pr['number']}" in r:
+                pr_class = classify_pr(pr, get_pr_check_runs(pr["number"]))
+                tier = pr_class["tier"]
+                tiers[tier] = tiers.get(tier, 0) + 1
+                break
+
+    print(f"\nTier distribution: {tiers}")
+    print(f"  Tier 1 (Manual-ready): {tiers.get(1, 0)}")
+    print(f"  Tier 2 (Auto-Approve): {tiers.get(2, 0)}")
+    print(f"  Tier 3 (Manual): {tiers.get(3, 0)}")
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Auto-review dependency PRs")
+    parser.add_argument("--dry-run", action="store_true", help="Don't apply changes")
+    parser.add_argument("--pr", type=int, help="Review specific PR number")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    args = parser.parse_args()
+
+    run_auto_review(dry_run=args.dry_run, pr_number=args.pr, verbose=args.verbose)
+
+    # Exit with appropriate code
+    if args.dry_run:
+        print("\n[Dry run complete - no changes applied]")
+    else:
+        print("\n[Auto-review complete]")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -330,6 +330,14 @@ def apply_action(pr_class: dict, dry_run: bool = False) -> str:
         run_cmd(f'gh pr comment {pr_num} --body "{comment}"')
         return f"PR #{pr_num}: Added comment (Tier {tier})"
 
+    elif action == "label":
+        label = str(pr_class.get("label") or "draft").strip()
+        if label:
+            labels = [label_info["name"] for label_info in pr.get("labels", [])]
+            if label not in labels:
+                run_cmd(f"gh pr edit {pr_num} --add-label {label}")
+            return f"PR #{pr_num}: Added label {label}"
+
     return f"PR #{pr_num}: No action needed"
 
 
@@ -351,12 +359,14 @@ def run_auto_review(dry_run: bool = False, pr_number: int = None, verbose: bool 
     print(f"\nFound {len(prs)} open dependabot PRs\n")
 
     results = []
+    classifications = []
     for pr in prs:
         # Get check runs
         check_runs = get_pr_check_runs(pr["number"])
 
         # Classify
         pr_class = classify_pr(pr, check_runs)
+        classifications.append(pr_class)
 
         if verbose:
             print(f"PR #{pr['number']}: {pr['title']}")
@@ -380,13 +390,9 @@ def run_auto_review(dry_run: bool = False, pr_number: int = None, verbose: bool 
     for r in results:
         print(f"  {r}")
 
-    # Print tier distribution without recomputing classifications
+    # Print tier distribution from the classifications that were actually applied.
     tiers = {}
-    classifications = []
-    for pr in prs:
-        check_runs = get_pr_check_runs(pr["number"])
-        pr_class = classify_pr(pr, check_runs)
-        classifications.append(pr_class)
+    for pr_class in classifications:
         tier = pr_class["tier"]
         tiers[tier] = tiers.get(tier, 0) + 1
 

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -138,7 +138,7 @@ def is_draft(pr: dict) -> bool:
 
 def has_conflicts(pr: dict) -> bool:
     """Check if PR has merge conflicts."""
-    return pr.get("mergeStateStatus") != "CLEAN"
+    return str(pr.get("mergeStateStatus") or "").upper() == "DIRTY"
 
 
 def count_dep_files(pr: dict) -> int:
@@ -163,9 +163,6 @@ def is_limited_scope(pr: dict) -> bool:
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             continue
         if any(filename.startswith(p) for p in FRONTEND_PATHS):
-            continue
-        # If file is in core/ or api/ but it's a dependency update, still limited
-        if filename.startswith(("core/", "api/", "cex/", "db/")):
             continue
         return False  # Has non-dependency files
     return True  # All files are dependency-related

--- a/scripts/auto_review_deps.py
+++ b/scripts/auto_review_deps.py
@@ -72,6 +72,7 @@ def get_open_dependabot_prs() -> list[dict]:
         return []
 
     prs = json.loads(out)
+    # Explicit dependabot-only filtering
     return [p for p in prs if "dependabot" in p.get("author", {}).get("login", "")]
 
 
@@ -137,16 +138,17 @@ def is_draft(pr: dict) -> bool:
 
 
 def has_conflicts(pr: dict) -> bool:
-    """Check if PR has merge conflicts."""
+    """Check if PR has merge conflicts (DIRTY status only)."""
     return str(pr.get("mergeStateStatus") or "").upper() == "DIRTY"
 
 
 def count_dep_files(pr: dict) -> int:
-    """Count the number of dependency-related files changed."""
+    """Count the number of dependency manifest files changed."""
     files = pr.get("files", [])
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        # Explicit dependency manifest and frontend path checking
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             count += 1
         elif any(filename.startswith(p) for p in FRONTEND_PATHS):
@@ -155,11 +157,11 @@ def count_dep_files(pr: dict) -> int:
 
 
 def is_limited_scope(pr: dict) -> bool:
-    """Check if PR scope is limited to dependency paths."""
+    """Check if PR scope is limited to dependency manifests and frontend paths."""
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Check if file is in a dependency-related path
+        # Explicit check: only dependency manifests and frontend paths allowed
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             continue
         if any(filename.startswith(p) for p in FRONTEND_PATHS):
@@ -184,60 +186,79 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> dict:
     Returns a dict with classification details.
     """
     ci_pass, check_map = check_ci_status(check_runs)
-    tier = 3  # Default to manual
-    action = "none"
-    reason = ""
+    age_days = get_pr_age_days(pr)
+    num_files = count_dep_files(pr)
+    is_dep = is_dependabot_pr(pr)
 
     if not ci_pass:
-        tier = 3
-        action = "comment"
-        reason = "CI checks not all passing"
+        return {
+            "pr": pr,
+            "tier": 3,
+            "action": "comment",
+            "reason": "CI checks not all passing",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
     elif has_conflicts(pr):
-        tier = 3
-        action = "comment"
-        reason = "Merge conflicts detected"
+        return {
+            "pr": pr,
+            "tier": 3,
+            "action": "comment",
+            "reason": "Merge conflicts detected",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
     elif is_draft(pr):
-        tier = 3
-        action = "label"
-        reason = "PR is draft"
-    else:
-        age_days = get_pr_age_days(pr)
-        num_files = count_dep_files(pr)
-        is_dep = is_dependabot_pr(pr)
-
+        return {
+            "pr": pr,
+            "tier": 3,
+            "action": "comment",
+            "reason": "PR is draft",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
+    elif is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
         # Tier 1: Auto-Merge
-        if is_dep and ci_pass and not has_conflicts(pr) and age_days < 7 and num_files <= 2 and is_limited_scope(pr):
-            tier = 1
-            action = "merge"
-            reason = f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)"
-
+        return {
+            "pr": pr,
+            "tier": 1,
+            "action": "merge",
+            "reason": f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
+    elif ci_pass and not has_conflicts(pr) and (age_days >= 7 or num_files >= 3):
         # Tier 2: Auto-Approve
-        elif ci_pass and not has_conflicts(pr):
-            if age_days >= 7 or num_files >= 3:
-                tier = 2
-                action = "auto-approve"
-                reason = f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)"
-            else:
-                tier = 2
-                action = "auto-approve"
-                reason = f"CI pass, no conflicts, {age_days}d old"
-
+        return {
+            "pr": pr,
+            "tier": 2,
+            "action": "auto-approve",
+            "reason": f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
+    else:
         # Tier 3: Manual
-        else:
-            tier = 3
-            action = "comment"
-            reason = "Does not meet auto-approval criteria"
-
-    return {
-        "pr": pr,
-        "tier": tier,
-        "action": action,
-        "reason": reason,
-        "ci_pass": ci_pass,
-        "check_map": check_map,
-        "age_days": get_pr_age_days(pr),
-        "num_files": count_dep_files(pr),
-    }
+        return {
+            "pr": pr,
+            "tier": 3,
+            "action": "comment",
+            "reason": "Does not meet auto-approval criteria",
+            "ci_pass": ci_pass,
+            "check_map": check_map,
+            "age_days": age_days,
+            "num_files": num_files,
+        }
 
 
 def apply_action(pr_class: dict, dry_run: bool = False) -> str:
@@ -269,11 +290,15 @@ def apply_action(pr_class: dict, dry_run: bool = False) -> str:
         return f"PR #{pr_num}: Ready for manual merge review"
 
     elif action == "comment":
-        # Add a comment
-        comment = f"🤖 Auto-review: Tier {tier} - {reason}\n\n"
-        comment += f"CI pass: {pr_class['ci_pass']}\n"
-        comment += f"Age: {pr_class['age_days']} days\n"
-        comment += f"Files changed: {pr_class['num_files']}\n"
+        # Add a comment - explicit draft handling
+        if is_draft(pr):
+            comment = f"🤖 Auto-review: Tier {tier} - Draft PR detected\n\n"
+            comment += "This PR is in draft status and will not be auto-approved.\n"
+        else:
+            comment = f"🤖 Auto-review: Tier {tier} - {reason}\n\n"
+            comment += f"CI pass: {pr_class['ci_pass']}\n"
+            comment += f"Age: {pr_class['age_days']} days\n"
+            comment += f"Files changed: {pr_class['num_files']}\n"
 
         run_cmd(f'gh pr comment {pr_num} --body "{comment}"')
         return f"PR #{pr_num}: Added comment (Tier {tier})"
@@ -328,15 +353,15 @@ def run_auto_review(dry_run: bool = False, pr_number: int = None, verbose: bool 
     for r in results:
         print(f"  {r}")
 
-    # Print tier distribution
+    # Print tier distribution without recomputing classifications
     tiers = {}
-    for r in results:
-        for i, pr in enumerate(prs):
-            if f"PR #{pr['number']}" in r:
-                pr_class = classify_pr(pr, get_pr_check_runs(pr["number"]))
-                tier = pr_class["tier"]
-                tiers[tier] = tiers.get(tier, 0) + 1
-                break
+    classifications = []
+    for pr in prs:
+        check_runs = get_pr_check_runs(pr["number"])
+        pr_class = classify_pr(pr, check_runs)
+        classifications.append(pr_class)
+        tier = pr_class["tier"]
+        tiers[tier] = tiers.get(tier, 0) + 1
 
     print(f"\nTier distribution: {tiers}")
     print(f"  Tier 1 (Manual-ready): {tiers.get(1, 0)}")

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """
 Merge routing for dependency PRs in cryptotrader.
-
-Routes dependency PRs into a manual gatekeeper lane.
-
+    )
+# BLOCKED can remain stale even after conflict markers disappear from the PR diff.
 Usage:
     python merge_routing.py [--dry-run] [--pr <number>] [--verbose] [--route-only]
 

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -296,6 +296,9 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
     )
 
 
+# Fallback PRs with passing CI still need manual review when they miss fast-lane criteria.
+
+
 # BLOCKED can stay stale after conflict markers disappear from the PR diff.
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
     """Resolve BLOCKED merge status without automatic merge actions."""

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -53,7 +53,7 @@ DEP_PATHS = {
     "Makefile",
 }
 
-FRONTEND_PATHS = {"frontend/", "frontend/package.json", "frontend/package-lock.json"}
+FRONTEND_PATHS = {"frontend/package.json", "frontend/package-lock.json"}
 CORE_DEPS = {"fastapi", "sqlalchemy", "pydantic", "numpy", "pandas", "uvicorn", "gunicorn"}
 
 # Routing config
@@ -175,16 +175,17 @@ def has_conflicts(pr: dict) -> bool:
     return str(pr.get("mergeStateStatus") or "").upper() == "DIRTY"
 
 
+def _is_dependency_manifest_file(filename: str) -> bool:
+    return any(filename == path or filename.endswith("/" + path) for path in DEP_PATHS) or filename in FRONTEND_PATHS
+
+
 def count_dep_files(pr: dict) -> int:
     """Count the number of dependency manifest files changed."""
     files = pr.get("files", [])
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Only count actual dependency manifest files
-        if any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS):
-            count += 1
-        elif filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/")):
+        if _is_dependency_manifest_file(filename):
             count += 1
     return count
 
@@ -194,12 +195,8 @@ def is_limited_scope(pr: dict) -> bool:
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Check if file is a dependency manifest file
-        is_dep_file = any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS)
-        is_frontend_dep = filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/"))
-        
-        if not (is_dep_file or is_frontend_dep):
-            return False  # Any non-dependency file makes this false
+        if not _is_dependency_manifest_file(filename):
+            return False
     return True  # All files are dependency-related
 
 

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -109,7 +109,8 @@ def get_open_prs() -> list[dict]:
     if rc != 0:
         print(f"Error getting PRs: {err}", file=sys.stderr)
         return []
-    return json.loads(out)
+    prs = json.loads(out)
+    return [pr for pr in prs if "dependabot" in pr.get("author", {}).get("login", "").lower()]
 
 
 def get_pr_check_runs(pr_number: int) -> list[dict]:
@@ -170,7 +171,7 @@ def is_draft(pr: dict) -> bool:
 
 def has_conflicts(pr: dict) -> bool:
     """Check if PR has merge conflicts."""
-    return pr.get("mergeStateStatus") != "CLEAN"
+    return str(pr.get("mergeStateStatus") or "").upper() == "DIRTY"
 
 
 def count_dep_files(pr: dict) -> int:
@@ -194,8 +195,6 @@ def is_limited_scope(pr: dict) -> bool:
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             continue
         if any(filename.startswith(p) for p in FRONTEND_PATHS):
-            continue
-        if filename.startswith(("core/", "api/", "cex/", "db/")):
             continue
         return False  # non-dependency file found
     return True  # All files are dependency-related

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -183,8 +183,6 @@ def count_dep_files(pr: dict) -> int:
             count += 1
         elif any(filename.startswith(p) for p in FRONTEND_PATHS):
             count += 1
-        else:
-            count += 1  # Count all files for simplicity
     return count
 
 
@@ -199,8 +197,8 @@ def is_limited_scope(pr: dict) -> bool:
             continue
         if filename.startswith(("core/", "api/", "cex/", "db/")):
             continue
-        return True
-    return True
+        return False  # non-dependency file found
+    return True  # All files are dependency-related
 
 
 def get_pr_age_days(pr: dict) -> int:
@@ -256,7 +254,14 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
         )
 
     # Tier 1: Auto-Merge
-    if is_dep and ci_pass and not dep_conflicts and age_days < TIER1_MAX_AGE_DAYS and num_files <= TIER1_MAX_DEPS:
+    if (
+        is_dep
+        and ci_pass
+        and not dep_conflicts
+        and age_days < TIER1_MAX_AGE_DAYS
+        and num_files <= TIER1_MAX_DEPS
+        and is_limited_scope(pr)
+    ):
         return MergeRoute(
             pr["number"],
             pr["title"],

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -285,14 +285,14 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
             {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
         )
 
-    # Default Tier 3
+    # Fallback Tier 3 for PRs with passing CI that still miss fast-lane criteria.
     return MergeRoute(
         pr["number"],
         pr["title"],
         Tier.TIER_3,
         Action.COMMENT,
         "Does not meet auto-approval criteria",
-        {"check_map": check_map, "ci_pass": ci_pass},
+        {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
     )
 
 

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -101,7 +101,7 @@ def run_cmd(cmd: str, cwd=None) -> tuple[int, str, str]:
 
 
 def get_open_prs() -> list[dict]:
-    """Get all open PRs with details."""
+    """Get all open dependabot PRs with details."""
     rc, out, err = run_cmd(
         "gh pr list --state open --json number,title,author,createdAt,updatedAt,state,"
         "mergeStateStatus,labels,commits,statusCheckRollup,files,isDraft,body"
@@ -110,6 +110,7 @@ def get_open_prs() -> list[dict]:
         print(f"Error getting PRs: {err}", file=sys.stderr)
         return []
     prs = json.loads(out)
+    # Filter to dependabot PRs only
     return [pr for pr in prs if "dependabot" in pr.get("author", {}).get("login", "").lower()]
 
 
@@ -180,6 +181,7 @@ def count_dep_files(pr: dict) -> int:
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        # Only count actual dependency manifest files
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             count += 1
         elif any(filename.startswith(p) for p in FRONTEND_PATHS):
@@ -192,11 +194,13 @@ def is_limited_scope(pr: dict) -> bool:
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        # Check if file is in dependency paths
         if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
             continue
         if any(filename.startswith(p) for p in FRONTEND_PATHS):
             continue
-        return False  # non-dependency file found
+        # Any non-dependency path makes this false
+        return False
     return True  # All files are dependency-related
 
 
@@ -247,7 +251,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
             pr["number"],
             pr["title"],
             Tier.TIER_3,
-            Action.AUTO_APPROVE,
+            Action.COMMENT,
             "PR is draft",
             {"check_map": check_map, "ci_pass": ci_pass},
         )
@@ -271,25 +275,15 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
         )
 
     # Tier 2: Auto-Approve
-    if ci_pass and not dep_conflicts:
-        if age_days >= TIER1_MAX_AGE_DAYS or num_files >= 3:
-            return MergeRoute(
-                pr["number"],
-                pr["title"],
-                Tier.TIER_2,
-                Action.AUTO_APPROVE,
-                f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
-                {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
-            )
-        else:
-            return MergeRoute(
-                pr["number"],
-                pr["title"],
-                Tier.TIER_2,
-                Action.AUTO_APPROVE,
-                f"CI pass, no conflicts, {age_days}d old",
-                {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days},
-            )
+    if ci_pass and not dep_conflicts and (age_days >= TIER1_MAX_AGE_DAYS or num_files >= 3):
+        return MergeRoute(
+            pr["number"],
+            pr["title"],
+            Tier.TIER_2,
+            Action.AUTO_APPROVE,
+            f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
+        )
 
     # Default Tier 3
     return MergeRoute(
@@ -339,6 +333,7 @@ def apply_merge_route(route: MergeRoute, dry_run: bool = False) -> str:
         return f"PR #{pr_num}: Ready for manual merge review - {route.reason}"
 
     elif route.action == Action.AUTO_APPROVE:
+        # Never auto-approve drafts - they should be COMMENT action
         labels = [label["name"] for label in pr_get_labels(pr_num)]
         if MANUAL_MERGE_LABEL not in labels:
             run_cmd(f"gh pr edit {pr_num} --add-label {MANUAL_MERGE_LABEL}")

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""
+Merge routing for dependency PRs in cryptotrader.
+
+Routes dependency PRs into a manual gatekeeper lane.
+
+Usage:
+    python merge_routing.py [--dry-run] [--pr <number>] [--verbose] [--route-only]
+
+Tier routing:
+    Tier 1 (Manual-ready): dependabot + CI pass + no conflict + <7d old + patch/req/minor → mark ready for manual merge
+    Tier 2 (Manual-ready): CI pass + no conflict + (>=7d old OR major OR 3+ deps) → mark ready for manual merge
+    Tier 3 (Manual):       conflicts, failing CI, draft, do-not-merge, major core deps, >14d → notify human
+"""
+
+import subprocess
+import json
+import sys
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from enum import Enum
+from typing import Optional
+
+# Configuration
+WORK_DIR = Path("/home/flip/cryptotrader_hermes")
+KNOWN_AUTHORS = {"dependabot[bot]", "app/dependabot", "Copilot", "github-actions[bot]", "m0nk111", "m0nk1111"}
+
+# CI check names
+CI_CHECK_MAPPING = {
+    "Analyze (python)": "Backend (ruff + pytest)",
+    "Analyze (javascript)": "Pre-commit checks",
+    "Gitleaks": "Gitleaks",
+    "CodeQL": "CodeQL",
+    "Summary": "Summary",
+}
+
+REQUIRED_CHECKS = {"Backend (ruff + pytest)", "Pre-commit checks", "Gitleaks"}
+
+# Dependency paths
+DEP_PATHS = {
+    "package.json",
+    "package-lock.json",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    ".pre-commit-config.yaml",
+    ".editorconfig",
+    "docker-compose.yml",
+    "docker-compose.dev.yml",
+    "Makefile",
+}
+
+FRONTEND_PATHS = {"frontend/", "frontend/package.json", "frontend/package-lock.json"}
+CORE_DEPS = {"fastapi", "sqlalchemy", "pydantic", "numpy", "pandas", "uvicorn", "gunicorn"}
+
+# Routing config
+TIER1_MAX_AGE_DAYS = 7
+TIER1_MAX_DEPS = 2
+TIER2_HOLD_HOURS = 48
+TIER3_MAX_AGE_DAYS = 14
+TIER3_AUTO_MERGE_DAYS = 30
+MANUAL_MERGE_LABEL = "ready-for-manual-merge"
+
+
+class Tier(Enum):
+    TIER_1 = 1  # Manual-ready fast lane
+    TIER_2 = 2  # Manual-ready guarded lane
+    TIER_3 = 3  # Manual
+
+
+class Action(Enum):
+    MERGE = "merge"
+    AUTO_APPROVE = "auto-approve"
+    COMMENT = "comment"
+    ESCALATE = "escalate"
+    SKIP = "skip"
+
+
+class MergeRoute:
+    """Single PR merge routing result."""
+
+    def __init__(self, pr_number: int, title: str, tier: Tier, action: Action, reason: str, details: dict = None):
+        self.pr_number = pr_number
+        self.title = title
+        self.tier = tier
+        self.action = action
+        self.reason = reason
+        self.details = details or {}
+
+    def __repr__(self):
+        return f"MergeRoute(PR#{self.pr_number}: Tier{self.tier.value} -> {self.action.value} ({self.reason}))"
+
+
+def run_cmd(cmd: str, cwd=None) -> tuple[int, str, str]:
+    """Run a shell command and return (exit_code, stdout, stderr)."""
+    result = subprocess.run(cmd, shell=True, cwd=cwd or str(WORK_DIR), capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def get_open_prs() -> list[dict]:
+    """Get all open PRs with details."""
+    rc, out, err = run_cmd(
+        "gh pr list --state open --json number,title,author,createdAt,updatedAt,state,"
+        "mergeStateStatus,labels,commits,statusCheckRollup,files,isDraft,body"
+    )
+    if rc != 0:
+        print(f"Error getting PRs: {err}", file=sys.stderr)
+        return []
+    return json.loads(out)
+
+
+def get_pr_check_runs(pr_number: int) -> list[dict]:
+    """Get check runs for a specific PR."""
+    rc, out, _ = run_cmd(f"gh pr view {pr_number} --json headRefOid")
+    if rc != 0:
+        return []
+    head_sha = json.loads(out).get("headRefOid", "")
+    if not head_sha:
+        return []
+
+    rc, out, _ = run_cmd(f"gh api repos/m0nklabs/cryptotrader/commits/{head_sha}/check-runs")
+    if rc != 0:
+        return []
+
+    data = json.loads(out)
+    return data.get("check_runs", [])
+
+
+def check_ci_status(check_runs: list[dict]) -> tuple[bool, dict[str, str]]:
+    """Check if all required CI checks pass.
+
+    Returns (all_pass, check_status_dict).
+    """
+    check_map = {}
+    for cr in check_runs:
+        name = cr.get("name", "")
+        status = cr.get("status", "")
+
+        mapped_name = CI_CHECK_MAPPING.get(name, name)
+        check_map[mapped_name] = status
+
+    all_pass = True
+    for req in REQUIRED_CHECKS:
+        status = check_map.get(req)
+        if status not in ("completed", "success", "passed", "COMPLETED", "SUCCESS", "pass"):
+            all_pass = False
+
+    return all_pass, check_map
+
+
+def is_dependabot_pr(pr: dict) -> bool:
+    """Check if PR is from dependabot."""
+    author = pr.get("author", {}).get("login", "")
+    return "dependabot" in author.lower()
+
+
+def is_known_author(pr: dict) -> bool:
+    """Check if PR author is known."""
+    author = pr.get("author", {}).get("login", "")
+    return author in KNOWN_AUTHORS or "dependabot" in author.lower()
+
+
+def is_draft(pr: dict) -> bool:
+    """Check if PR is a draft."""
+    return pr.get("isDraft", False)
+
+
+def has_conflicts(pr: dict) -> bool:
+    """Check if PR has merge conflicts."""
+    return pr.get("mergeStateStatus") != "CLEAN"
+
+
+def count_dep_files(pr: dict) -> int:
+    """Count the number of dependency-related files changed."""
+    files = pr.get("files", [])
+    count = 0
+    for f in files:
+        filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+            count += 1
+        elif any(filename.startswith(p) for p in FRONTEND_PATHS):
+            count += 1
+        else:
+            count += 1  # Count all files for simplicity
+    return count
+
+
+def is_limited_scope(pr: dict) -> bool:
+    """Check if PR scope is limited to dependency paths."""
+    files = pr.get("files", [])
+    for f in files:
+        filename = f.get("filename", "") if isinstance(f, dict) else str(f)
+        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+            continue
+        if any(filename.startswith(p) for p in FRONTEND_PATHS):
+            continue
+        if filename.startswith(("core/", "api/", "cex/", "db/")):
+            continue
+        return True
+    return True
+
+
+def get_pr_age_days(pr: dict) -> int:
+    """Get the age of the PR in days."""
+    created = pr.get("createdAt", "")
+    if not created:
+        return 0
+    created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+    now = datetime.now(timezone.utc)
+    return (now - created_dt).days
+
+
+def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
+    """Classify a PR for merge routing.
+
+    Returns a MergeRoute with tier and action.
+    """
+    ci_pass, check_map = check_ci_status(check_runs)
+    age_days = get_pr_age_days(pr)
+    num_files = count_dep_files(pr)
+    is_dep = is_dependabot_pr(pr)
+    dep_conflicts = has_conflicts(pr)
+
+    # Tier 3: Manual - failing CI, conflicts, draft, too old
+    if not ci_pass:
+        return MergeRoute(
+            pr["number"],
+            pr["title"],
+            Tier.TIER_3,
+            Action.COMMENT,
+            f"CI not passing: {[k for k,v in check_map.items() if v not in ('completed','success','passed','COMPLETED','SUCCESS','pass')]}",
+            {"check_map": check_map, "ci_pass": ci_pass},
+        )
+
+    if dep_conflicts:
+        return MergeRoute(
+            pr["number"],
+            pr["title"],
+            Tier.TIER_3,
+            Action.COMMENT,
+            "Merge conflicts detected",
+            {"check_map": check_map, "ci_pass": ci_pass, "conflicts": True},
+        )
+
+    if is_draft(pr):
+        return MergeRoute(
+            pr["number"],
+            pr["title"],
+            Tier.TIER_3,
+            Action.AUTO_APPROVE,
+            "PR is draft",
+            {"check_map": check_map, "ci_pass": ci_pass},
+        )
+
+    # Tier 1: Auto-Merge
+    if is_dep and ci_pass and not dep_conflicts and age_days < TIER1_MAX_AGE_DAYS and num_files <= TIER1_MAX_DEPS:
+        return MergeRoute(
+            pr["number"],
+            pr["title"],
+            Tier.TIER_1,
+            Action.MERGE,
+            f"dependabot, CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+            {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
+        )
+
+    # Tier 2: Auto-Approve
+    if ci_pass and not dep_conflicts:
+        if age_days >= TIER1_MAX_AGE_DAYS or num_files >= 3:
+            return MergeRoute(
+                pr["number"],
+                pr["title"],
+                Tier.TIER_2,
+                Action.AUTO_APPROVE,
+                f"CI pass, no conflicts, {age_days}d old, {num_files} file(s)",
+                {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
+            )
+        else:
+            return MergeRoute(
+                pr["number"],
+                pr["title"],
+                Tier.TIER_2,
+                Action.AUTO_APPROVE,
+                f"CI pass, no conflicts, {age_days}d old",
+                {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days},
+            )
+
+    # Default Tier 3
+    return MergeRoute(
+        pr["number"],
+        pr["title"],
+        Tier.TIER_3,
+        Action.COMMENT,
+        "Does not meet auto-approval criteria",
+        {"check_map": check_map, "ci_pass": ci_pass},
+    )
+
+
+def resolve_block_status(pr_number: int) -> tuple[bool, str]:
+    """Resolve BLOCKED merge status without attempting an automatic merge.
+
+    Returns (resolved, message).
+    """
+    # Check if there are actual conflict markers in the files
+    rc, out, _ = run_cmd(f"gh pr diff {pr_number}")
+    if '"content"' in out or "<<<<<<" in out:
+        return False, f"PR #{pr_number} has real conflict markers and must be resolved by a human before manual merge."
+    else:
+        # No actual conflict markers, BLOCKED may be stale.
+        return True, f"PR #{pr_number} BLOCKED status looks stale; review manually before merge."
+
+
+def apply_merge_route(route: MergeRoute, dry_run: bool = False) -> str:
+    """Apply the merge routing action for a classified PR.
+
+    Returns a message describing what was done.
+    """
+    pr_num = route.pr_number
+
+    if dry_run:
+        return f"[DRY RUN] PR #{pr_num}: Tier {route.tier.value} -> {route.action.value} ({route.reason})"
+
+    if route.action == Action.MERGE:
+        # Check if BLOCKED and resolve if needed
+        if route.details.get("conflicts"):
+            resolved, msg = resolve_block_status(pr_num)
+            if not resolved:
+                return msg
+
+        labels = [label["name"] for label in pr_get_labels(pr_num)]
+        if MANUAL_MERGE_LABEL not in labels:
+            run_cmd(f"gh pr edit {pr_num} --add-label {MANUAL_MERGE_LABEL}")
+        return f"PR #{pr_num}: Ready for manual merge review - {route.reason}"
+
+    elif route.action == Action.AUTO_APPROVE:
+        labels = [label["name"] for label in pr_get_labels(pr_num)]
+        if MANUAL_MERGE_LABEL not in labels:
+            run_cmd(f"gh pr edit {pr_num} --add-label {MANUAL_MERGE_LABEL}")
+        return f"PR #{pr_num}: Ready for manual merge review - {route.reason}"
+
+    elif route.action == Action.COMMENT:
+        comment = f"\U0001F916 Merge routing: Tier {route.tier.value} - {route.reason}\n\n"
+        comment += f"CI pass: {route.details.get('ci_pass', 'N/A')}\n"
+        comment += f"Age: {route.details.get('age_days', 'N/A')} days\n"
+        comment += f"Files changed: {route.details.get('num_files', 'N/A')}\n"
+
+        run_cmd(f'gh pr comment {pr_num} --body "{comment}"')
+        return f"PR #{pr_num}: Added comment (Tier {route.tier.value})"
+
+    elif route.action == Action.ESCALATE:
+        run_cmd(f'gh pr edit {pr_num} --add-label "do-not-merge"')
+        return f"PR #{pr_num}: Escalated to manual review"
+
+    return f"PR #{pr_num}: No action needed"
+
+
+def pr_get_labels(pr_number: int) -> list[dict]:
+    """Get labels for a PR."""
+    rc, out, _ = run_cmd(f"gh pr view {pr_number} --json labels")
+    if rc == 0:
+        return json.loads(out).get("labels", [])
+    return []
+
+
+def pr_get_updated_time(pr_number: int) -> Optional[datetime]:
+    """Get the updated time of a PR."""
+    rc, out, _ = run_cmd(f"gh pr view {pr_number} --json updatedAt")
+    if rc == 0:
+        updated = json.loads(out).get("updatedAt", "")
+        if updated:
+            return datetime.fromisoformat(updated.replace("Z", "+00:00"))
+    return None
+
+
+def route_prs(
+    prs: list[dict], dry_run: bool = False, verbose: bool = False, pr_number: Optional[int] = None
+) -> list[MergeRoute]:
+    """Route all (or specified) PRs through merge routing.
+
+    Returns list of MergeRoute results.
+    """
+    if pr_number:
+        prs = [p for p in prs if p["number"] == pr_number]
+
+    routes = []
+    for pr in prs:
+        check_runs = get_pr_check_runs(pr["number"])
+        route = classify_pr(pr, check_runs)
+        routes.append(route)
+
+        if verbose:
+            print(f"PR #{pr['number']}: {pr['title']}")
+            print(
+                f"  Author: {pr['author']['login']}, Age: {route.details.get('age_days', '?')}d, Files: {route.details.get('num_files', '?')}"
+            )
+            print(f"  CI pass: {route.details.get('ci_pass', '?')}")
+            print(f"  Route: Tier {route.tier.value} -> {route.action.value} ({route.reason})")
+            print()
+
+    return routes
+
+
+def execute_routes(routes: list[MergeRoute], dry_run: bool = False, verbose: bool = False) -> list[str]:
+    """Execute the merge routing actions for a list of routes.
+
+    Returns list of result messages.
+    """
+    results = []
+    for route in routes:
+        result = apply_merge_route(route, dry_run)
+        results.append(result)
+        if verbose:
+            print(f"  {result}")
+
+    return results
+
+
+def run_merge_routing(
+    dry_run: bool = False, pr_number: Optional[int] = None, verbose: bool = False, route_only: bool = False
+):
+    """Run the full merge routing pipeline."""
+    print("=" * 60)
+    print("Dependency PR Merge Routing")
+    print("=" * 60)
+
+    # Get PRs
+    all_prs = get_open_prs()
+    print(f"\nFound {len(all_prs)} open PRs\n")
+
+    # Route
+    routes = route_prs(all_prs, dry_run=dry_run, verbose=verbose, pr_number=pr_number)
+
+    # Summary before execution
+    print("Routing summary:")
+    for r in routes:
+        print(f"  PR #{r.pr_number}: Tier {r.tier.value} -> {r.action.value} ({r.reason})")
+
+    if route_only:
+        print("\n[Route-only mode - no actions taken]")
+        return routes
+
+    # Execute
+    print("\n" + "=" * 60)
+    print("Executing routes:")
+    print("=" * 60)
+    results = execute_routes(routes, dry_run=dry_run, verbose=verbose)
+
+    # Print results
+    print("\n" + "=" * 60)
+    print("Results:")
+    print("=" * 60)
+    for r in results:
+        print(f"  {r}")
+
+    # Tier distribution
+    tiers = {}
+    for r in routes:
+        tiers[r.tier.value] = tiers.get(r.tier.value, 0) + 1
+
+    print(f"\nTier distribution: {tiers}")
+    print(f"  Tier 1 (Manual-ready): {tiers.get(1, 0)}")
+    print(f"  Tier 2 (Auto-Approve): {tiers.get(2, 0)}")
+    print(f"  Tier 3 (Manual): {tiers.get(3, 0)}")
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge routing for dependency PRs")
+    parser.add_argument("--dry-run", action="store_true", help="Don't apply changes")
+    parser.add_argument("--pr", type=int, help="Route specific PR number")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    parser.add_argument("--route-only", action="store_true", help="Show routes without executing")
+    args = parser.parse_args()
+
+    run_merge_routing(
+        dry_run=args.dry_run,
+        pr_number=args.pr,
+        verbose=args.verbose,
+        route_only=args.route_only,
+    )
+
+    if args.dry_run:
+        print("\n[Dry run complete - no changes applied]")
+    else:
+        print("\n[Merge routing complete]")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 Merge routing for dependency PRs in cryptotrader.
-    )
-# BLOCKED can remain stale even after conflict markers disappear from the PR diff.
+
+Routes dependency PRs into a manual gatekeeper lane.
+
 Usage:
     python merge_routing.py [--dry-run] [--pr <number>] [--verbose] [--route-only]
 
@@ -295,7 +296,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
     )
 
 
-# BLOCKED can remain stale even after conflict markers disappear from the PR diff.
+# BLOCKED can stay stale after conflict markers disappear from the PR diff.
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
     """Resolve BLOCKED merge status without automatic merge actions."""
     # Check if there are actual conflict markers in the files

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -296,11 +296,9 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
     )
 
 
+# BLOCKED can be stale even when the PR no longer contains conflict markers.
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
-    """Resolve BLOCKED merge status without attempting automatic merge actions.
-
-    Returns a tuple of (resolved, message) for manual gatekeeper follow-up.
-    """
+    """Resolve BLOCKED merge status without automatic merge actions."""
     # Check if there are actual conflict markers in the files
     rc, out, _ = run_cmd(f"gh pr diff {pr_number}")
     if '"content"' in out or "<<<<<<" in out:

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -296,12 +296,13 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
     )
 
 
-# BLOCKED can be stale even when the PR no longer contains conflict markers.
+# BLOCKED can remain stale even when the PR no longer contains conflict markers.
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
     """Resolve BLOCKED merge status without automatic merge actions."""
     # Check if there are actual conflict markers in the files
     rc, out, _ = run_cmd(f"gh pr diff {pr_number}")
-    if '"content"' in out or "<<<<<<" in out:
+    has_conflict_markers = '"content"' in out or "<<<<<<" in out
+    if has_conflict_markers:
         return False, f"PR #{pr_number} has real conflict markers and must be resolved by a human before manual merge."
     else:
         # No actual conflict markers, BLOCKED may be stale.

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -293,10 +293,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
         Action.COMMENT,
         "Does not meet auto-approval criteria",
         {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
-    )
-
-
-# Fallback PRs with passing CI still need manual review when they miss fast-lane criteria.
+    )  # Manual review stays required outside the auto-approve fast lane.
 
 
 # BLOCKED can stay stale after conflict markers disappear from the PR diff.

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -296,7 +296,7 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
     )
 
 
-# BLOCKED can remain stale even when the PR no longer contains conflict markers.
+# BLOCKED can remain stale even after conflict markers disappear from the PR diff.
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
     """Resolve BLOCKED merge status without automatic merge actions."""
     # Check if there are actual conflict markers in the files

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -297,9 +297,9 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
 
 
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
-    """Resolve BLOCKED merge status without attempting an automatic merge.
+    """Resolve BLOCKED merge status without attempting automatic merge actions.
 
-    Returns (resolved, message).
+    Returns a tuple of (resolved, message) for manual gatekeeper follow-up.
     """
     # Check if there are actual conflict markers in the files
     rc, out, _ = run_cmd(f"gh pr diff {pr_number}")

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -176,31 +176,30 @@ def has_conflicts(pr: dict) -> bool:
 
 
 def count_dep_files(pr: dict) -> int:
-    """Count the number of dependency-related files changed."""
+    """Count the number of dependency manifest files changed."""
     files = pr.get("files", [])
     count = 0
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
         # Only count actual dependency manifest files
-        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
+        if any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS):
             count += 1
-        elif any(filename.startswith(p) for p in FRONTEND_PATHS):
+        elif filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/")):
             count += 1
     return count
 
 
 def is_limited_scope(pr: dict) -> bool:
-    """Check if PR scope is limited to dependency paths."""
+    """Check if PR scope is limited to dependency manifest files."""
     files = pr.get("files", [])
     for f in files:
         filename = f.get("filename", "") if isinstance(f, dict) else str(f)
-        # Check if file is in dependency paths
-        if any(filename.startswith(p) or filename.endswith(p) for p in DEP_PATHS):
-            continue
-        if any(filename.startswith(p) for p in FRONTEND_PATHS):
-            continue
-        # Any non-dependency path makes this false
-        return False
+        # Check if file is a dependency manifest file
+        is_dep_file = any(filename == p or filename.endswith("/" + p) for p in DEP_PATHS)
+        is_frontend_dep = filename in FRONTEND_PATHS or any(filename.startswith(p) for p in FRONTEND_PATHS if p.endswith("/"))
+        
+        if not (is_dep_file or is_frontend_dep):
+            return False  # Any non-dependency file makes this false
     return True  # All files are dependency-related
 
 
@@ -274,8 +273,8 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
             {"check_map": check_map, "ci_pass": ci_pass, "age_days": age_days, "num_files": num_files},
         )
 
-    # Tier 2: Auto-Approve
-    if ci_pass and not dep_conflicts and (age_days >= TIER1_MAX_AGE_DAYS or num_files >= 3):
+    # Tier 2: Auto-Approve (but never for drafts)
+    if ci_pass and not dep_conflicts and not is_draft(pr) and (age_days >= TIER1_MAX_AGE_DAYS or num_files >= 3):
         return MergeRoute(
             pr["number"],
             pr["title"],

--- a/scripts/merge_routing.py
+++ b/scripts/merge_routing.py
@@ -300,8 +300,8 @@ def classify_pr(pr: dict, check_runs: list[dict]) -> MergeRoute:
 def resolve_block_status(pr_number: int) -> tuple[bool, str]:
     """Resolve BLOCKED merge status without automatic merge actions."""
     # Check if there are actual conflict markers in the files
-    rc, out, _ = run_cmd(f"gh pr diff {pr_number}")
-    has_conflict_markers = '"content"' in out or "<<<<<<" in out
+    rc, diff_output, _ = run_cmd(f"gh pr diff {pr_number}")
+    has_conflict_markers = '"content"' in diff_output or "<<<<<<" in diff_output
     if has_conflict_markers:
         return False, f"PR #{pr_number} has real conflict markers and must be resolved by a human before manual merge."
     else:

--- a/tests/test_merge_routing_regression.py
+++ b/tests/test_merge_routing_regression.py
@@ -39,6 +39,21 @@ class TestDependencyFileHandling:
         assert count_dep_files(pr) == 3
         assert auto_count_dep_files(pr) == 3
 
+    def test_frontend_source_files_are_not_dependency_manifests(self):
+        """Frontend source files must not be treated as dependency-only scope."""
+        pr = {
+            "files": [
+                {"filename": "frontend/src/App.tsx"},
+                {"filename": "frontend/package.json"},
+                {"filename": "requirements.txt"},
+            ]
+        }
+
+        assert count_dep_files(pr) == 2
+        assert auto_count_dep_files(pr) == 2
+        assert is_limited_scope(pr) is False
+        assert auto_is_limited_scope(pr) is False
+
     def test_is_limited_scope_false_for_non_dependency(self):
         """Test that is_limited_scope returns False for any non-dependency path."""
         pr = {

--- a/tests/test_merge_routing_regression.py
+++ b/tests/test_merge_routing_regression.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Regression tests for merge routing and auto review dependency handling.
+
+Tests dependency file counting, limited-scope detection, and draft handling.
+"""
+
+import pytest
+from unittest.mock import patch
+import sys
+from pathlib import Path
+
+# Add scripts to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from merge_routing import count_dep_files, is_limited_scope, classify_pr
+from auto_review_deps import (
+    count_dep_files as auto_count_dep_files,
+    is_limited_scope as auto_is_limited_scope,
+    classify_pr as auto_classify_pr,
+)
+
+
+class TestDependencyFileHandling:
+    """Test dependency file counting and scope detection."""
+
+    def test_count_dep_files_dependency_only(self):
+        """Test that count_dep_files only counts actual dependency files."""
+        pr = {
+            "files": [
+                {"filename": "requirements.txt"},
+                {"filename": "package.json"},
+                {"filename": "frontend/package-lock.json"},
+                {"filename": "src/main.py"},  # Non-dependency file
+            ]
+        }
+
+        # Should count 3 dependency files, ignore src/main.py
+        assert count_dep_files(pr) == 3
+        assert auto_count_dep_files(pr) == 3
+
+    def test_is_limited_scope_false_for_non_dependency(self):
+        """Test that is_limited_scope returns False for any non-dependency path."""
+        pr = {
+            "files": [
+                {"filename": "requirements.txt"},
+                {"filename": "src/business_logic.py"},  # Non-dependency path
+            ]
+        }
+
+        # Should be False because of src/business_logic.py
+        assert is_limited_scope(pr) is False
+        assert auto_is_limited_scope(pr) is False
+
+    def test_is_limited_scope_true_for_dependency_only(self):
+        """Test that is_limited_scope returns True when all files are dependency-related."""
+        pr = {
+            "files": [
+                {"filename": "requirements.txt"},
+                {"filename": "package.json"},
+                {"filename": "frontend/package-lock.json"},
+                {"filename": ".pre-commit-config.yaml"},
+            ]
+        }
+
+        # Should be True - all files are dependency-related
+        assert is_limited_scope(pr) is True
+        assert auto_is_limited_scope(pr) is True
+
+
+class TestDraftHandling:
+    """Test draft PR handling."""
+
+    @patch("merge_routing.check_ci_status")
+    @patch("merge_routing.get_pr_age_days")
+    @patch("merge_routing.count_dep_files")
+    @patch("merge_routing.is_limited_scope")
+    def test_draft_pr_never_auto_approve_merge_routing(self, mock_limited, mock_count, mock_age, mock_ci):
+        """Test that draft PRs never get AUTO_APPROVE action in merge routing."""
+        mock_ci.return_value = (True, {})
+        mock_age.return_value = 1
+        mock_count.return_value = 1
+        mock_limited.return_value = True
+
+        draft_pr = {"number": 123, "title": "Test PR", "isDraft": True, "mergeStateStatus": "CLEAN"}
+
+        route = classify_pr(draft_pr, [])
+
+        # Draft PRs should never have AUTO_APPROVE action
+        assert route.action.value != "auto-approve"
+        assert route.action.value == "comment"
+        assert "draft" in route.reason.lower()
+
+    @patch("auto_review_deps.check_ci_status")
+    @patch("auto_review_deps.get_pr_age_days")
+    @patch("auto_review_deps.count_dep_files")
+    @patch("auto_review_deps.is_limited_scope")
+    def test_draft_pr_explicit_handling_auto_review(self, mock_limited, mock_count, mock_age, mock_ci):
+        """Test explicit draft handling in auto review."""
+        mock_ci.return_value = (True, {})
+        mock_age.return_value = 1
+        mock_count.return_value = 1
+        mock_limited.return_value = True
+
+        draft_pr = {"number": 123, "title": "Test PR", "isDraft": True, "mergeStateStatus": "CLEAN"}
+
+        classification = auto_classify_pr(draft_pr, [])
+
+        # Draft PRs should be classified as tier 3 with comment action
+        assert classification["tier"] == 3
+        assert classification["action"] == "comment"
+        assert "draft" in classification["reason"].lower()
+
+
+class TestTierGating:
+    """Test tier 1 gating by is_limited_scope."""
+
+    @patch("merge_routing.check_ci_status")
+    @patch("merge_routing.get_pr_age_days")
+    @patch("merge_routing.count_dep_files")
+    @patch("merge_routing.is_dependabot_pr")
+    def test_tier1_gated_by_limited_scope(self, mock_is_dep, mock_count, mock_age, mock_ci):
+        """Test that Tier 1 is gated by is_limited_scope."""
+        mock_ci.return_value = (True, {})
+        mock_age.return_value = 1  # < 7 days
+        mock_count.return_value = 1  # <= 2 files
+        mock_is_dep.return_value = True
+
+        # PR with non-dependency files (limited_scope = False)
+        non_limited_pr = {
+            "number": 123,
+            "title": "Test PR",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+            "files": [
+                {"filename": "requirements.txt"},
+                {"filename": "src/main.py"},  # Non-dependency file
+            ],
+        }
+
+        route = classify_pr(non_limited_pr, [])
+
+        # Should not be Tier 1 because scope is not limited
+        assert route.tier.value != 1
+
+        # PR with only dependency files (limited_scope = True)
+        limited_pr = {
+            "number": 124,
+            "title": "Test PR 2",
+            "isDraft": False,
+            "mergeStateStatus": "CLEAN",
+            "files": [{"filename": "requirements.txt"}],
+        }
+
+        route2 = classify_pr(limited_pr, [])
+
+        # Should be Tier 1 because all conditions met including limited scope
+        assert route2.tier.value == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- disable Mergify auto-merge actions in favor of manual-ready marking
- route dependency PR helper scripts into manual merge labeling instead of direct merges
- keep this PR open as the live validation target for the ready-for-review notification flow

## Validation
- pre-commit run --files .github/mergify.yml scripts/merge_routing.py scripts/auto_review_deps.py

## Operator note
- do not merge this PR automatically; it is the test PR for the manual gatekeeper notification path