### PR TITLE
test(validate_signals.py): document exit code in module docstring (#403)

### DIFF
--- a/scripts/validate_signals.py
+++ b/scripts/validate_signals.py
@@ -9,6 +9,8 @@ This script validates the complete flow:
 
 Usage:
     python scripts/validate_signals.py
+
+Exits 0 on success.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Add one line to the top-level docstring of `scripts/validate_signals.py` documenting that the script exits 0 on success.

This is a pure documentation change — no behavior modification.

## Diff

```diff
 Usage:
     python scripts/validate_signals.py
+
+Exits 0 on success.
 """
```

## Why

Closes #403.

This PR is a self-contained pipeline-validation test for the OpenHands `github-pr-review` skill on a different file than #399 (`validate_budget_logic.py`), to confirm the skill is not overfit to a single target.

## Acceptance criteria

- [x] `git diff` on `scripts/validate_signals.py` shows one added line in the docstring
- [x] `python scripts/validate_signals.py` still runs end-to-end and exits 0
- [x] No behavior change
- [x] No dependencies bumped

---

🤖 This PR was created by an AI agent (OpenHands) on behalf of @m0nk111 in response to the '@openhands' mention on #403.